### PR TITLE
[추가] SimpleMarkDownParser 오픈소스 추가 및 테스트 코드 삽입 

### DIFF
--- a/Project_SOS/Podfile
+++ b/Project_SOS/Podfile
@@ -14,4 +14,6 @@ pod 'Firebase/Storage'
 
 pod 'Google-Mobile-Ads-SDK'
 
+pod "SimpleMarkdownParser", '~> 0.5.3'
+
 end

--- a/Project_SOS/Podfile.lock
+++ b/Project_SOS/Podfile.lock
@@ -47,6 +47,7 @@ PODS:
     - nanopb/encode (= 0.3.8)
   - nanopb/decode (0.3.8)
   - nanopb/encode (0.3.8)
+  - SimpleMarkdownParser (0.5.3)
 
 DEPENDENCIES:
   - Firebase/Auth
@@ -54,6 +55,7 @@ DEPENDENCIES:
   - Firebase/Database
   - Firebase/Storage
   - Google-Mobile-Ads-SDK
+  - SimpleMarkdownParser (~> 0.5.3)
 
 SPEC CHECKSUMS:
   Firebase: 1492bf04e1b73a7353b4fb2cf5a20bac9692f341
@@ -67,7 +69,8 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: 8e329f1b599f2512c6b10676d45736bcc2cbbeb0
   GTMSessionFetcher: 5ad62e8200fa00ed011fe5e08d27fef72c5b1429
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  SimpleMarkdownParser: 53ce31aa92465b11a00c1232dc88f11379fcb015
 
-PODFILE CHECKSUM: 8a0e9888e3841542d96561bfd0fcbd38884980e9
+PODFILE CHECKSUM: 4e9824eb71882e1ae7526d4b3d65c260750b964e
 
 COCOAPODS: 1.3.1

--- a/Project_SOS/Podfile.lock
+++ b/Project_SOS/Podfile.lock
@@ -1,35 +1,32 @@
 PODS:
-  - Firebase/Auth (4.1.1):
+  - Firebase/Auth (4.0.4):
     - Firebase/Core
-    - FirebaseAuth (= 4.1.1)
-  - Firebase/Core (4.1.1):
-    - FirebaseAnalytics (= 4.0.3)
-    - FirebaseCore (= 4.0.6)
-  - Firebase/Database (4.1.1):
+    - FirebaseAuth (= 4.0.0)
+  - Firebase/Core (4.0.4):
+    - FirebaseAnalytics (= 4.0.2)
+    - FirebaseCore (= 4.0.4)
+  - Firebase/Database (4.0.4):
     - Firebase/Core
-    - FirebaseDatabase (= 4.0.2)
-  - Firebase/Storage (4.1.1):
+    - FirebaseDatabase (= 4.0.0)
+  - Firebase/Storage (4.0.4):
     - Firebase/Core
-    - FirebaseStorage (= 2.0.1)
-  - FirebaseAnalytics (4.0.3):
+    - FirebaseStorage (= 2.0.0)
+  - FirebaseAnalytics (4.0.2):
     - FirebaseCore (~> 4.0)
     - FirebaseInstanceID (~> 2.0)
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
-    - nanopb (~> 0.3)
-  - FirebaseAuth (4.1.1):
+  - FirebaseAuth (4.0.0):
     - FirebaseAnalytics (~> 4.0)
     - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseCore (4.0.6):
+  - FirebaseCore (4.0.4):
     - GoogleToolboxForMac/NSData+zlib (~> 2.1)
     - nanopb (~> 0.3)
-  - FirebaseDatabase (4.0.2):
+  - FirebaseDatabase (4.0.0):
     - FirebaseAnalytics (~> 4.0)
+  - FirebaseInstanceID (2.0.0):
     - FirebaseCore (~> 4.0)
-    - leveldb-library (~> 1.18)
-  - FirebaseInstanceID (2.0.2):
-    - FirebaseCore (~> 4.0)
-  - FirebaseStorage (2.0.1):
+  - FirebaseStorage (2.0.0):
     - FirebaseAnalytics (~> 4.0)
     - FirebaseCore (~> 4.0)
     - GTMSessionFetcher/Core (~> 1.1)
@@ -45,7 +42,6 @@ PODS:
     - GoogleToolboxForMac/NSString+URLArguments (= 2.1.1)
   - GoogleToolboxForMac/NSString+URLArguments (2.1.1)
   - GTMSessionFetcher/Core (1.1.11)
-  - leveldb-library (1.18.3)
   - nanopb (0.3.8):
     - nanopb/decode (= 0.3.8)
     - nanopb/encode (= 0.3.8)
@@ -60,17 +56,16 @@ DEPENDENCIES:
   - Google-Mobile-Ads-SDK
 
 SPEC CHECKSUMS:
-  Firebase: 052c0de688fc87b414996eea13e223dd9fee3fa2
-  FirebaseAnalytics: 76f754d37ca5b04f36856729b6af3ca0152d1069
-  FirebaseAuth: f8b07aa83de60d606b4eadd81484b3ac2097ea3e
-  FirebaseCore: 28def3c643989c97ea5a69ea5000f5fa9902b9fd
-  FirebaseDatabase: 4d1a10639a42cae26e094296951b53c689e5e191
-  FirebaseInstanceID: c4c7fca62c7b7330caee5da04f19a37ea37bb1c1
-  FirebaseStorage: 661fc1f8d4131891d256b62e82a45ace8b3f0c3b
+  Firebase: 1492bf04e1b73a7353b4fb2cf5a20bac9692f341
+  FirebaseAnalytics: ad41720e3e67fc63fbe3d2948d3e26932a8de311
+  FirebaseAuth: ebb6abcbabae00fc47446d690c19ce68d8484fde
+  FirebaseCore: cfc042628ef9f20debe09c0eb683135fcd404cb4
+  FirebaseDatabase: d829b3a8c3e2ac7a16773c5df226966b0805dfc2
+  FirebaseInstanceID: 9fbf536668f4d3f0880e7438456dabd1376e294b
+  FirebaseStorage: 8110a1ed2034c8fbfd83890d2acc9cdbbd99afec
   Google-Mobile-Ads-SDK: 1bdf1a4244d0553b1840239874c209c01aef055f
   GoogleToolboxForMac: 8e329f1b599f2512c6b10676d45736bcc2cbbeb0
   GTMSessionFetcher: 5ad62e8200fa00ed011fe5e08d27fef72c5b1429
-  leveldb-library: 10fb39c39e243db4af1828441162405bbcec1404
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
 
 PODFILE CHECKSUM: 8a0e9888e3841542d96561bfd0fcbd38884980e9

--- a/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
+++ b/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		D86539571F5E8C2B00D34790 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D86539551F5E8C2B00D34790 /* LaunchScreen.storyboard */; };
 		FE4FE6E91F6C24E00052AFB0 /* JS_AdMobTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4FE6E81F6C24E00052AFB0 /* JS_AdMobTestViewController.swift */; };
 		FE4FE6EB1F6C25030052AFB0 /* JS_AdMobTest.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FE4FE6EA1F6C25030052AFB0 /* JS_AdMobTest.storyboard */; };
+		FE8D1C1F1F71035D007B4396 /* JS_TestSimpleMarkDownParserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8D1C1E1F71035D007B4396 /* JS_TestSimpleMarkDownParserViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,7 @@
 		DBEC6AE63B063AEBB4F31C52 /* Pods-Project_SOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Project_SOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Project_SOS/Pods-Project_SOS.debug.xcconfig"; sourceTree = "<group>"; };
 		FE4FE6E81F6C24E00052AFB0 /* JS_AdMobTestViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JS_AdMobTestViewController.swift; path = JS_AdmobTest/JS_AdMobTestViewController.swift; sourceTree = "<group>"; };
 		FE4FE6EA1F6C25030052AFB0 /* JS_AdMobTest.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = JS_AdMobTest.storyboard; path = JS_AdmobTest/JS_AdMobTest.storyboard; sourceTree = "<group>"; };
+		FE8D1C1E1F71035D007B4396 /* JS_TestSimpleMarkDownParserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JS_TestSimpleMarkDownParserViewController.swift; path = JS_AdmobTest/JS_TestSimpleMarkDownParserViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,8 +161,9 @@
 		FE4FE6E71F6C24B00052AFB0 /* JS_AdMobTest */ = {
 			isa = PBXGroup;
 			children = (
-				FE4FE6E81F6C24E00052AFB0 /* JS_AdMobTestViewController.swift */,
 				FE4FE6EA1F6C25030052AFB0 /* JS_AdMobTest.storyboard */,
+				FE4FE6E81F6C24E00052AFB0 /* JS_AdMobTestViewController.swift */,
+				FE8D1C1E1F71035D007B4396 /* JS_TestSimpleMarkDownParserViewController.swift */,
 			);
 			name = JS_AdMobTest;
 			sourceTree = "<group>";
@@ -284,12 +287,14 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-Project_SOS/Pods-Project_SOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
+				"${BUILT_PRODUCTS_DIR}/SimpleMarkdownParser/SimpleMarkdownParser.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SimpleMarkdownParser.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -313,6 +318,7 @@
 				6A33C8581F614941005FC0A8 /* BY_DetailViewController.swift in Sources */,
 				6A33C8561F614931005FC0A8 /* BY_MainViewController.swift in Sources */,
 				D8321BF31F6D17A2006D7506 /* SM_DataCenter.swift in Sources */,
+				FE8D1C1F1F71035D007B4396 /* JS_TestSimpleMarkDownParserViewController.swift in Sources */,
 				6A33C8541F60FBB6005FC0A8 /* README.md in Sources */,
 				D865394D1F5E8C2B00D34790 /* AppDelegate.swift in Sources */,
 				6A33C8641F614D19005FC0A8 /* BY_MainTableViewCell.swift in Sources */,

--- a/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
+++ b/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
@@ -284,14 +284,12 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-Project_SOS/Pods-Project_SOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
-				"${BUILT_PRODUCTS_DIR}/leveldb-library/leveldb.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/leveldb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Project_SOS/Project_SOS/Info.plist
+++ b/Project_SOS/Project_SOS/Info.plist
@@ -2,15 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSAllowsArbitraryLoadsForMedia</key>
-		<true/>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
-		<true/>
-	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -29,12 +20,19 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSAllowsArbitraryLoadsForMedia</key>
+		<true/>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
-
-	<string>SM_DataTestStoryboard</string>
-
+	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Project_SOS/Project_SOS/JS_AdmobTest/JS_AdMobTest.storyboard
+++ b/Project_SOS/Project_SOS/JS_AdmobTest/JS_AdMobTest.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="HhU-jv-Nlq">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="z1t-zF-flc">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -34,6 +35,48 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eWB-4q-4gw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="386" y="-107"/>
+        </scene>
+        <!--Test Simple Mark Down Parser View Controller-->
+        <scene sceneID="hdn-37-fwp">
+            <objects>
+                <viewController id="z1t-zF-flc" customClass="JS_TestSimpleMarkDownParserViewController" customModule="Project_SOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="TpZ-HC-0si"/>
+                        <viewControllerLayoutGuide type="bottom" id="8qO-tg-4Xf"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="evr-QJ-ND4">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZV1-ZJ-YW3">
+                                <rect key="frame" x="16" y="28" width="343" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abP-rh-ztv">
+                                <rect key="frame" x="184" y="597" width="154" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Move ADmobTestView"/>
+                                <connections>
+                                    <segue destination="HhU-jv-Nlq" kind="presentation" id="quG-EL-lGe"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="ZV1-ZJ-YW3" firstAttribute="trailing" secondItem="evr-QJ-ND4" secondAttribute="trailingMargin" id="OtH-Fj-3p2"/>
+                            <constraint firstItem="ZV1-ZJ-YW3" firstAttribute="leading" secondItem="evr-QJ-ND4" secondAttribute="leadingMargin" id="kKz-sd-Drm"/>
+                            <constraint firstItem="ZV1-ZJ-YW3" firstAttribute="top" secondItem="TpZ-HC-0si" secondAttribute="bottom" constant="8" id="sE1-pI-DLs"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="uiLabelMarkdownTest" destination="ZV1-ZJ-YW3" id="4yh-OT-paR"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4se-V3-J6y" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-410" y="-107"/>
         </scene>
     </scenes>
 </document>

--- a/Project_SOS/Project_SOS/JS_AdmobTest/JS_AdMobTestViewController.swift
+++ b/Project_SOS/Project_SOS/JS_AdmobTest/JS_AdMobTestViewController.swift
@@ -7,15 +7,15 @@
 //
 
 import UIKit
-import GoogleMobileAds
+//import GoogleMobileAds //애드몹 라이브러리 관련 이미지가 없다는 치명적인 에러가 있어서 잠시 주석 처리합니다.
 
 class JS_AdMobTestViewController: UIViewController {
     
-    var bannerView: GADBannerView!
+    // var bannerView: GADBannerView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        /*
         bannerView = GADBannerView(adSize: kGADAdSizeFullBanner)
         self.view.addSubview(bannerView)
         
@@ -23,6 +23,7 @@ class JS_AdMobTestViewController: UIViewController {
         bannerView.rootViewController = self
         
         bannerView.load(GADRequest())
+ */
     }
 
     override func didReceiveMemoryWarning() {

--- a/Project_SOS/Project_SOS/JS_AdmobTest/JS_TestSimpleMarkDownParserViewController.swift
+++ b/Project_SOS/Project_SOS/JS_AdmobTest/JS_TestSimpleMarkDownParserViewController.swift
@@ -1,0 +1,72 @@
+//
+//  JS_TestSimpleMarkDownParserViewController.swift
+//  Project_SOS
+//
+//  Created by leejaesung on 2017. 9. 19..
+//  Copyright © 2017년 joe. All rights reserved.
+//
+
+import UIKit
+import SimpleMarkdownParser
+
+class JS_TestSimpleMarkDownParserViewController: UIViewController {
+    
+    @IBOutlet var uiLabelMarkdownTest: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let rawTextArray: [String] = [
+            "# 첫번째 제목",
+            "## 두번째 제목",
+            "### 세번째 제목",
+            "",
+            "1. 기울림체 *테스트* -> 한글 불가능",
+            "2. 볼드체 **테스트**",
+            "3. 둘다 ***테스트*** -> 한글은 기울림체가 불가능",
+            "4. 취소선 ~테스트~",
+            "5. 특수문자 표시 \\*테스트\\*",
+            "6. 소스코드(강조) 표시 `테스트` -> 지원 불가 / 커스터마이징 필요",
+            "",
+            "### 별표시 목록 테스트",
+            "* First item",
+            "* Second item",
+            "",
+            "### 링크 테스트",
+            "Testing a link to [github](https://github.com/crescentflare/SimpleMarkdownParser).",
+            ""
+        ]
+        // Array가 아닌, "\n"이 들어간 String으로 아래의 메소드에 던집니다.
+        let markdownText:String = rawTextArray.joined(separator: "\n")
+        
+        // 컨버팅을 거쳐 UILabel에 뿌리는 메소드입니다.
+        defaultAttributedStringConversion(markdownText: markdownText)
+        
+        
+        // UILabel에 제스쳐를 먹여서 링크를 터치했을 때, 반응하도록 합니다.
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapOnLabel(_:)))
+        uiLabelMarkdownTest.addGestureRecognizer(gestureRecognizer)
+        
+    }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    // MARK: SimpleMarkdownConverter를 이용해 UILabel에 뿌리는 코드
+    // 이 안에서 몇가지 커스터마이징이 가능합니다.
+    func defaultAttributedStringConversion(markdownText: String) {
+        let attributedString = SimpleMarkdownConverter.toAttributedString(defaultFont: uiLabelMarkdownTest.font, markdownText: markdownText)
+        uiLabelMarkdownTest.attributedText = attributedString
+    }
+    
+    // 링크를 눌렀을 때, 사파리로 웹사이트를 열도록 하는 코드
+    func didTapOnLabel(_ gesture: UITapGestureRecognizer) {
+        if let url: URL = gesture.findUrl(onLabel: uiLabelMarkdownTest) {
+            UIApplication.shared.openURL(url)
+        }
+    }
+    
+}
+


### PR DESCRIPTION
사용하기로 결정한 `심플마크다운파서` 오픈소스를 `podfile`에 추가하였고, 관련 테스트 코드를 `JS_AdMobTest` 폴더에 추가하였습니다.
몇가지 주의 사항이 있습니다.

**< 주의 1 >**
프로젝트 설정에서 메인 스토리보드를 `Main.storyboard`로 교체하였습니다.
저도 선미님도 실수 하는 것 같은데, 작업할 때는 잠시 스토리보드를 본인 것으로 교체하더라도 꼭 PR 때는 원래대로(Main으로..) 복구해놔야겠어요.

**< 주의 2 >**
무슨 이유인지, `import GoogleMobileAds`을 하기만 하면, 아래 에러를 뿜으면서 빌드되지 않네요. (...)
라이브러리가 꼬였다는 것 같은데, 코코아팟을 건들다가 뭔가 문제가 생긴 것만 같습니다.
당장 해결될 여지는 안보여서 일단, PR을 위해 애드몹 관련 코드를 모두 주석 처리하였고..

마크다운 관련해서 선미님이 작업 하실 때, 보셔야 할 것 같아서 먼저 PR 해요.

```
dyld: Library not loaded: @rpath/GTMSessionFetcher.framework/GTMSessionFetcher
  Referenced from: /Users/leejaesung/Library/Developer/CoreSimulator/Devices/CB72543C-D5A0-4BC0-B355-359C9C284387/data/Containers/Bundle/Application/36AA720F-0756-413E-AB26-26415D6AA851/Project_SOS.app/Project_SOS
  Reason: image not found
(lldb) 
```