### PR TITLE
[추가] 캐릭터 선택에 따라 Firebase 이벤트 기록

### DIFF
--- a/Project_SOS/Project_SOS/BY_CharacterChoiceViewController.swift
+++ b/Project_SOS/Project_SOS/BY_CharacterChoiceViewController.swift
@@ -87,6 +87,17 @@ class BY_CharacterChoiceViewController: UIViewController {
         
         saveUserUidAtDatabase()
         
+        //캐릭터 설정창에서 완료버튼을 눌렀을 때, 어떤 캐릭터를 설정했는지 파이어베이스에 이벤트로 저장
+        switch realCharacterString {
+        case "보영":
+            Analytics.logEvent("BY_Selected", parameters: ["id":realCharacterString])
+        case "선미":
+            Analytics.logEvent("SM_Selected", parameters: ["id":realCharacterString])
+        case "재성":
+            Analytics.logEvent("JS_Selected", parameters: ["id":realCharacterString])
+        default: break
+        }
+        
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: "characterSelected"), object: realCharacterString)
         self.dismiss(animated: true, completion: nil)
     }

--- a/Project_SOS/Project_SOS/BY_CharacterChoiceViewController.swift
+++ b/Project_SOS/Project_SOS/BY_CharacterChoiceViewController.swift
@@ -27,8 +27,7 @@ class BY_CharacterChoiceViewController: UIViewController {
     /*******************************************/
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        
+
     }
     
     override func didReceiveMemoryWarning() {

--- a/Project_SOS/Project_SOS/BY_DetailViewController.swift
+++ b/Project_SOS/Project_SOS/BY_DetailViewController.swift
@@ -160,12 +160,15 @@ class BY_DetailViewController: UIViewController {
         case 0:
             self.mailingCharacterImageView.image = #imageLiteral(resourceName: "BYFace")
             self.mailingCharacterTextLabel.text = "보영에게\n메일링"
+            Analytics.logEvent("BY_Tapped", parameters: ["id":"보영"])
         case 1:
             self.mailingCharacterImageView.image = #imageLiteral(resourceName: "SMFace")
             self.mailingCharacterTextLabel.text = "선미에게\n메일링"
+            Analytics.logEvent("SM_Tapped", parameters: ["id":"선미"])
         case 2:
             self.mailingCharacterImageView.image = #imageLiteral(resourceName: "JSFace")
             self.mailingCharacterTextLabel.text = "재성에게\n메일링"
+            Analytics.logEvent("JS_Tapped", parameters: ["id":"재성"])
         default:
             break
         }

--- a/Project_SOS/Project_SOS/BY_DetailViewController.swift
+++ b/Project_SOS/Project_SOS/BY_DetailViewController.swift
@@ -17,7 +17,7 @@ class BY_DetailViewController: UIViewController {
     
     var questionID:Int?
     var byAnswer:[[String:String]] = []
-	var jsAnswer:[[String:String]] = []
+    var jsAnswer:[[String:String]] = []
     var smAnswer:[[String:String]] = []
     
     //네비게이션 바
@@ -47,7 +47,7 @@ class BY_DetailViewController: UIViewController {
     
     //테이블뷰
     @IBOutlet weak var detailTableView: UITableView!
-
+    
     //테이블뷰 헤더
     @IBOutlet weak var summaryTextLabel: UILabel!
     @IBOutlet weak var characterSelectSegmentedControl: UISegmentedControl!
@@ -62,12 +62,12 @@ class BY_DetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        
         //네비게이션 바 UI 설정
         self.navigationBarLogoButtonOutlet.isUserInteractionEnabled = false
         self.navigationController?.navigationBar.backIndicatorImage = #imageLiteral(resourceName: "BackButton")
         self.navigationController?.navigationBar.backIndicatorTransitionMaskImage = #imageLiteral(resourceName: "BackButton")
         self.navigationController?.navigationBar.topItem?.title = ""
+        
         
         //SearchVC을 통해 Present 되었을 때 NavigationBar 역할할 View 설정
         if self.isPresentedBySearchVC == true {
@@ -90,11 +90,12 @@ class BY_DetailViewController: UIViewController {
         //노티: 캐릭터선택VC에서 어떤 캐릭터를 선택하냐에 따라서, 해당 캐릭터의 설명이 우선적으로 나올 수 있도록 SegmentController를 조정하는 역할을 할 것입니다.
         NotificationCenter.default.addObserver(self, selector: #selector(BY_DetailViewController.callNotiForCharacter(_:)), name: Notification.Name("characterSelected"), object: nil)
         
-        self.loadData(from: questionID!)
-        self.loadBYAnswer(from: questionID!)
+        //데이터 핸들링
+        guard let realQuestionID:Int = self.questionID else {return print("QuestionID가 없습니다.")}
         
-        print("이 디테일뷰는 \(self.questionID) 번째 질문입니다.")
-
+        self.loadData(from: realQuestionID)
+        self.loadBYAnswer(from: realQuestionID)
+        self.loadLikeData(questionID: realQuestionID)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -112,11 +113,12 @@ class BY_DetailViewController: UIViewController {
             return
         }
         selectSeugeForCharacter(nameOf: selectedCharacter)
+        
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-
+        
         guard let headerView = self.detailTableView.tableHeaderView else {return}
         
         let size = headerView.systemLayoutSizeFitting(UILayoutFittingCompressedSize)
@@ -195,24 +197,16 @@ class BY_DetailViewController: UIViewController {
     @IBAction func shareButtonAction(_ sender: UIButton) {
     }
     
-    //TODO: (선미님!)여기에 즐겨찾기에 대한 기능을 구현해주세요
     @IBAction func favoriteButtonAction(_ sender: UIButton) {
-        guard let realFavoriteButtonImage = self.favoriteButtonOutlet.image(for: .normal) else {return}
-        
-        switch realFavoriteButtonImage {
-        case #imageLiteral(resourceName: "Like_off"): self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
-        case #imageLiteral(resourceName: "likeCountIcon"): self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
-        default:
-            break
-        }
-        
-        likeBtnAction()
+        self.likeButtonAction()
     }
-
+    
     
     //SearchVC을 통해 Present 되었을 때 네비게이션 바 역할을 할 뷰상의 버튼 설정
     //--Back Button
     @IBAction func navigationViewBackButtonAction(_ sender: UIButton) {
+        
+        //네비게이션 효과
         let transition = CATransition()
         transition.duration = 0.3
         transition.type = kCATransitionPush
@@ -228,18 +222,9 @@ class BY_DetailViewController: UIViewController {
     }
     
     //--Like Button
-    //TODO: (선미님!)여기에 즐겨찾기에 대한 기능을 구현해주세요 / 기존 NavigationBar 상의 버튼에 구현했던 것과 동일 + Firebase Database와 연동되어야 함
     @IBAction func navigationViewFavoriteButtonAction(_ sender: UIButton) {
-        guard let realFavoriteButtonImage = self.navigationViewFavoriteButtonOutlet.image(for: .normal) else {return}
-        
-        switch realFavoriteButtonImage {
-        case #imageLiteral(resourceName: "Like_off"): self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
-        case #imageLiteral(resourceName: "likeCountIcon"): self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
-        default:
-            break
-        }
+        self.likeButtonAction()
     }
-    
     
     //선택한 캐릭터가 있다면, 해당 캐릭터 Segue가 띄워져 있도록 설정
     func selectSeugeForCharacter(nameOf:String) {
@@ -269,6 +254,97 @@ class BY_DetailViewController: UIViewController {
     func callNotiForCharacter(_ sender:Notification) {
         guard let realSelectedCharacterName:String = sender.object as? String else {return}
         self.selectSeugeForCharacter(nameOf: realSelectedCharacterName)
+    }
+    
+    // 데이터 영역
+    
+    // BY Func: 좋아요 구현 부분 테스트
+    // --- BY: 해당 질문의 좋아요 여부
+    func loadLikeData(questionID:Int) {
+        Database.database().reference().child(Constants.like).queryOrdered(byChild: Constants.like_User_Id).queryEqual(toValue: Auth.auth().currentUser?.uid).observeSingleEvent(of: .value, with: { (snapshot) in
+            guard let tempLikeDatas = snapshot.value as? [String:[String:Any]] else {return print("못불러옴 \(snapshot.value)")}
+            
+            let filteredLikeData = tempLikeDatas.filter({ (dic:(key: String, value: [String : Any])) -> Bool in
+                let questionNumber:Int = dic.value[Constants.like_QuestionId] as! Int
+                return questionNumber == questionID
+            })
+            
+            switch filteredLikeData.count {
+            case 0:
+                self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
+                self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
+                print("안찍히나오")
+            case 1:
+                self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
+                self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
+            default:
+                print("좋아요 이미지 에러: \(filteredLikeData)")
+            }
+        }, withCancel: { (error) in
+            print("좋아요 불러오는 에러입니다", error.localizedDescription)
+        })
+    }
+    
+    // --- BY: 좋아요 버튼 액션. 별표(좋아요)를 누를 때마다 데이터 및 UI를 반영하여 나타냅니다.
+    func likeButtonAction() {
+        guard let realQuestionID = self.questionID else {return}
+        Database.database().reference().child(Constants.like).queryOrdered(byChild: Constants.like_User_Id).queryEqual(toValue: Auth.auth().currentUser?.uid).observeSingleEvent(of: .value, with: { (snapshot) in
+            
+            if snapshot.childrenCount != 0 {
+                guard let tempLikeDatas = snapshot.value as? [String:[String:Any]] else {return print("못불러옴 \(snapshot.value)")}
+                
+                let filteredLikeData = tempLikeDatas.filter({ (dic:(key: String, value: [String : Any])) -> Bool in
+                    let questionNumber:Int = dic.value[Constants.like_QuestionId] as! Int
+                    return questionNumber == realQuestionID
+                })
+                
+                switch filteredLikeData.count {
+                case 0:
+                    self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
+                    self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
+                    Database.database().reference().child(Constants.like).childByAutoId().setValue([Constants.like_QuestionId:realQuestionID,
+                                                                                                    Constants.like_User_Id:Auth.auth().currentUser?.uid])
+                case 1:
+                    self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
+                    self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
+                    Database.database().reference().child(Constants.like).child(filteredLikeData[0].key).setValue(nil)
+                default:
+                    print("좋아요 버튼액션에러: \(filteredLikeData)")
+                }
+            }else{
+                self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
+                self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
+                Database.database().reference().child(Constants.like).childByAutoId().setValue([Constants.like_QuestionId:realQuestionID,
+                                                                                                Constants.like_User_Id:Auth.auth().currentUser?.uid])
+            }
+        }) { (error) in
+            print("좋아요 액션 에러", error.localizedDescription)
+        }
+    }
+    
+    func loadData(from question_ID:Int) {
+        Database.database().reference().child(Constants.question).child("\(question_ID)").observe(.value, with: { (snapshot) in
+            guard let data = snapshot.value as? [String:Any] else { return }
+            self.titleTextLabel.text = data[Constants.question_QuestionTitle] as! String
+            self.hiddenTitleTextLabel.text = data[Constants.question_QuestionTitle] as! String
+            guard let tagArray = data[Constants.question_Tag] as? String else { return }
+            self.tagTextLabel.text = tagArray
+            guard let summaryArray = data[Constants.question_Summary] as? [String] else { return }
+            self.summaryTextLabel.text = "\(summaryArray[0])\n\(summaryArray[1])\n\(summaryArray[2])"
+            
+        }) { (error) in
+            print(error.localizedDescription)
+        }
+    }
+    
+    func loadBYAnswer(from question_ID:Int) {
+        Database.database().reference().child(Constants.question).child("\(question_ID)").child(Constants.question_BYAnswer).observeSingleEvent(of: .value, with: { (snapshot) in
+            guard let byAnswerArray = snapshot.value as? [[String:String]] else { return }
+            self.byAnswer = byAnswerArray
+            self.detailTableView.reloadData()
+        }) { (error) in
+            print(error.localizedDescription)
+        }
     }
     
 }
@@ -413,62 +489,4 @@ extension BY_DetailViewController: UITableViewDelegate {
         return 72
     }
     
-    // SM Func
-    func likeBtnAction() {
-
-        guard let realQuestionID:Int = self.questionID else { return print("가드렛걸림")}
-        
-        Database.database().reference().child(Constants.like).queryOrdered(byChild: Constants.like_User_Id).queryEqual(toValue: Auth.auth().currentUser?.uid).observeSingleEvent(of: .value, with: { (snapshot) in
-            
-            guard let likeData = snapshot.value as? [String:[String:Any]] else { return }
-            print("데이터가있슴니돠아아아아ㅏ==================:", likeData)
-            let filteredData = likeData.filter({ (dic:(key:String, value:[String:Any])) -> Bool in
-                var filteredQuestionID = dic.value[Constants.like_QuestionId]
-                return realQuestionID == filteredQuestionID as! Int
-            })
-            print("필터된데이터!!!!!!!!!!!!!!:", filteredData)
-            switch filteredData.count {
-            case 0 : Database.database().reference().child(Constants.like).childByAutoId().setValue([Constants.like_QuestionId:realQuestionID,Constants.like_User_Id:Auth.auth().currentUser?.uid])
-//            self.getLikeCount(question:realQuestionID)
-            DataCenter.standard.favoriteQuestions.append(realQuestionID)
-            print("좋아요리스트!!!!!!!!!!!!!!!!",DataCenter.standard.favoriteQuestions)
-            case 1 :
-                Database.database().reference().child(Constants.like).child(filteredData[0].key).setValue(nil)
-//                self.getLikeCount(question: realQuestionID)
-                if let deleteIndex:Int = DataCenter.standard.favoriteQuestions.index(of: realQuestionID) {
-                    DataCenter.standard.favoriteQuestions.remove(at: deleteIndex)
-                }
-                print("좋아요리스트!!!!!!!!!!!!!!!!",DataCenter.standard.favoriteQuestions)
-            default:
-                print("error!!!!!!!!!!!!!!")
-            }
-            
-        }) { (error) in
-            print("좋아요 error: \(error.localizedDescription)")
-        }
-    }
-    func loadData(from question_ID:Int) {
-        Database.database().reference().child(Constants.question).child("\(question_ID)").observe(.value, with: { (snapshot) in
-            guard let data = snapshot.value as? [String:Any] else { return }
-            self.titleTextLabel.text = data[Constants.question_QuestionTitle] as! String
-            self.hiddenTitleTextLabel.text = data[Constants.question_QuestionTitle] as! String
-            guard let tagArray = data[Constants.question_Tag] as? String else { return }
-            self.tagTextLabel.text = tagArray
-            guard let summaryArray = data[Constants.question_Summary] as? [String] else { return }
-            self.summaryTextLabel.text = "\(summaryArray[0])\n\(summaryArray[1])\n\(summaryArray[2])"
-     
-        }) { (error) in
-            print(error.localizedDescription)
-        }
-    }
-
-    func loadBYAnswer(from question_ID:Int) {
-        Database.database().reference().child(Constants.question).child("\(question_ID)").child(Constants.question_BYAnswer).observeSingleEvent(of: .value, with: { (snapshot) in
-            guard let byAnswerArray = snapshot.value as? [[String:String]] else { return }
-            self.byAnswer = byAnswerArray
-            self.detailTableView.reloadData()
-        }) { (error) in
-            print(error.localizedDescription)
-        }
-    }
 }

--- a/Project_SOS/Project_SOS/BY_MainTableViewController.swift
+++ b/Project_SOS/Project_SOS/BY_MainTableViewController.swift
@@ -49,8 +49,6 @@ class BY_MainTableViewController: UITableViewController {
         }
     }
 
-    
-    
     //네비게이션 바
     @IBOutlet weak var navigationBarLogoButtonOutlet: UIButton!
     
@@ -94,14 +92,12 @@ class BY_MainTableViewController: UITableViewController {
         
         //셀라인 삭제
         self.tableView.separatorStyle = .none
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         
         self.tableView.reloadData()
-        
         tableView.register(UINib.init(nibName: "BY_MainTableViewCell", bundle: nil), forCellReuseIdentifier: "MainTableViewCell")
         awakeFromNib()
         
@@ -154,16 +150,14 @@ class BY_MainTableViewController: UITableViewController {
 
         cell.titleQuestionLabel.text = self.questionTitleData[indexPath.row]
         cell.tagLabel?.text = self.questionTagData[indexPath.row]
-        cell.getLikeCount(question: indexPath.row)
+        cell.loadLikeDatafor(questionID: indexPath.row)
         
         if self.isSearchBarClicked == false {
             if self.isfavoriteTableView {
                 cell.titleQuestionLabel.text = ""
-                cell.getLikeCount(question: indexPath.row)
             }else{
                 cell.titleQuestionLabel.text = self.questionTitleData[indexPath.row]
                 cell.tagLabel?.text = self.questionTagData[indexPath.row]
-                cell.getLikeCount(question: indexPath.row)
             }
         }else if self.isSearchBarClicked == true {
             cell.titleQuestionLabel.text = self.visibleResults[indexPath.row]
@@ -182,18 +176,5 @@ class BY_MainTableViewController: UITableViewController {
         let nextViewController:BY_DetailViewController = storyboard?.instantiateViewController(withIdentifier: "DetailViewController") as! BY_DetailViewController
         nextViewController.questionID = self.selectedQuestionID
         self.navigationController?.pushViewController(nextViewController, animated: true)
-    }
-
-}
-
-//가져온 QuestionTitle 어레이와 QuetionID 어레이를 [QuetionTitle:QuestionID] 딕셔너리로 만들도록 해주는 Extension
-extension Dictionary {
-    public init(keys:[Key], values:[Value]) {
-        precondition(keys.count == values.count)
-        
-        self.init()
-        for (index, key) in keys.enumerated() {
-            self[key] = values[index]
-        }
     }
 }

--- a/Project_SOS/Project_SOS/BY_SearchResultsViewController.swift
+++ b/Project_SOS/Project_SOS/BY_SearchResultsViewController.swift
@@ -42,6 +42,12 @@ class BY_SearchResultsViewController: BY_MainTableViewController, UISearchResult
         }
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        
+        print("써치뷰가 사라질것임")
+    }
+    
     
     /*******************************************/
     //MARK:-         Functions                 //
@@ -64,6 +70,8 @@ class BY_SearchResultsViewController: BY_MainTableViewController, UISearchResult
         self.selectedQuestionID = currentCell.questionID!
         nextViewController.questionID = self.selectedQuestionID
 
+        //좋아요 갯수 연동
+        currentCell.loadLikeDatafor(questionID: indexPath.row)
         
         //Present를 Navigation Push(show) 처럼 보이게 설정
         let transition = CATransition()


### PR DESCRIPTION
~연달아 PR 날려서 죄송합니다.~

지난 번 회의에서 이야기 했던, 캐릭터 선택시 파이어베이스에 이벤트로 기록하는 부분 추가했습니다.
구현자체는 정말 간단한데요, 좀 더 파보고 싶어요. 기능적인 면을요. 많은 것을 기록할 수 있을 것 같습니다.

참고로 제가 이해한 부분 간략히 말씀드리면,

#### 이벤트는 Realtime Database 와 달리 실시간으로 이벤트 탭에 기록되지 않습니다. 그 이유는 다음과 같이 파베 문서에서 설명하고 있어요. 
***
일반적으로 앱이 기록하는 이벤트는 약 1시간 동안 취합된 후 일괄 업로드됩니다. 이렇게 하는 이유는 최종 사용자 기기의 배터리를 절약하고 네트워크 데이터 사용량을 줄이기 위함입니다. 그러나 개발 기기에서 디버그 모드를 사용 설정하여 이벤트를 업로드하는 지연 시간을 최소화하면 분석 구현을 검증하고 DebugView 보고서에서 분석 결과를 조회할 수 있습니다.
***

#### 그럼 이게 되는지 안되는지 어떻게 확인하느냐? 역시 이 것도 문서에 나와있습니다. 
***
개발 기기에서 디버그 모드를 사용 설정한 후 Firebase용 Google 애널리틱스의 상단 탐색 메뉴에서 StreamView 옆의 화살표를 선택하고 DebugView를 선택하여 DebugView로 이동합니다. 그런 다음 앱 사용을 시작하여 DebugView 보고서에 앱의 이벤트가 기록되는지 확인합니다.
***

이렇게 하면 다음과 같이 실시간으로 앱사용에 대한 내용이 보입니다. **짱신기**
![screen shot 2017-09-29 at 1 07 19 pm](https://user-images.githubusercontent.com/27915244/31000625-fa5f8692-a517-11e7-8a6b-7520bb7d1b31.png)

#### 받으신 다음에 각자 구현해보시려면, 설정해주셔야 할 사전작업이 있습니다.

Xcode 디버그 콘솔에서 이 이벤트를 보려면 애널리틱스 디버깅을 사용 설정합니다.

![screen shot 2017-09-29 at 1 16 26 pm](https://user-images.githubusercontent.com/27915244/31000666-6d7154da-a518-11e7-8270-92a22779df68.png)
Xcode에서 `Product` > `Scheme` > `Edit scheme...` 
을 선택합니다.

![screen shot 2017-09-29 at 1 17 13 pm](https://user-images.githubusercontent.com/27915244/31000688-9d4b3766-a518-11e7-8a9c-358c196b0657.png)
왼쪽 메뉴에서 `Run` -> `Arguments` 탭을 선택한 뒤 `Arguments Passed On Launch` 섹션에 `-FIRAnalyticsDebugEnabled` 를 추가합니다.

