### PR TITLE
[Create] 공유 기능 구현 완료

### DIFF
--- a/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
+++ b/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		FE0E3E971F7C0F4A00FCBCCD /* JS_TestAdMobViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0E3E941F7C0F4900FCBCCD /* JS_TestAdMobViewController.swift */; };
 		FE0E3E981F7C0F4A00FCBCCD /* JS_TestSendMailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0E3E951F7C0F4A00FCBCCD /* JS_TestSendMailViewController.swift */; };
 		FE0E3E9A1F7C184900FCBCCD /* JS_TestWebViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0E3E991F7C184900FCBCCD /* JS_TestWebViewViewController.swift */; };
+		FEA1675C1F7E264E00C6E9BA /* JS_TestShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA1675B1F7E264E00C6E9BA /* JS_TestShareViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -79,6 +80,7 @@
 		FE0E3E941F7C0F4900FCBCCD /* JS_TestAdMobViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JS_TestAdMobViewController.swift; path = JS_Test/JS_TestAdMobViewController.swift; sourceTree = "<group>"; };
 		FE0E3E951F7C0F4A00FCBCCD /* JS_TestSendMailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JS_TestSendMailViewController.swift; path = JS_Test/JS_TestSendMailViewController.swift; sourceTree = "<group>"; };
 		FE0E3E991F7C184900FCBCCD /* JS_TestWebViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JS_TestWebViewViewController.swift; path = JS_Test/JS_TestWebViewViewController.swift; sourceTree = "<group>"; };
+		FEA1675B1F7E264E00C6E9BA /* JS_TestShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JS_TestShareViewController.swift; path = JS_Test/JS_TestShareViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +206,7 @@
 				FE0E3E941F7C0F4900FCBCCD /* JS_TestAdMobViewController.swift */,
 				FE0E3E951F7C0F4A00FCBCCD /* JS_TestSendMailViewController.swift */,
 				FE0E3E991F7C184900FCBCCD /* JS_TestWebViewViewController.swift */,
+				FEA1675B1F7E264E00C6E9BA /* JS_TestShareViewController.swift */,
 			);
 			name = JS_Test;
 			sourceTree = "<group>";
@@ -349,6 +352,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A15CBCC1F72B20200F74B1A /* BY_SearchPresentOverNavigationBarViewController.swift in Sources */,
+				FEA1675C1F7E264E00C6E9BA /* JS_TestShareViewController.swift in Sources */,
 				FE0E3E981F7C0F4A00FCBCCD /* JS_TestSendMailViewController.swift in Sources */,
 				6A33C85C1F6149C1005FC0A8 /* BY_CharacterChoiceViewController.swift in Sources */,
 				FE0E3E971F7C0F4A00FCBCCD /* JS_TestAdMobViewController.swift in Sources */,

--- a/Project_SOS/Project_SOS/JS_Test/JS_Test.storyboard
+++ b/Project_SOS/Project_SOS/JS_Test/JS_Test.storyboard
@@ -123,6 +123,34 @@
             </objects>
             <point key="canvasLocation" x="727" y="668"/>
         </scene>
+        <!--Test Share View Controller-->
+        <scene sceneID="V1B-Gm-twQ">
+            <objects>
+                <viewController id="2Fz-gv-lA9" customClass="JS_TestShareViewController" customModule="Project_SOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="IB4-a3-nL7"/>
+                        <viewControllerLayoutGuide type="bottom" id="wmL-Em-ago"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="aF1-Cn-pxi">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bqJ-JQ-kQo">
+                                <rect key="frame" x="142" y="72" width="90" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Share Button"/>
+                                <connections>
+                                    <action selector="buttonShareAction:" destination="2Fz-gv-lA9" eventType="touchUpInside" id="o5I-en-iJP"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZKf-xg-gdT" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1492" y="668"/>
+        </scene>
         <!--Test Simple Mark Down Parser View Controller-->
         <scene sceneID="hdn-37-fwp">
             <objects>
@@ -136,7 +164,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="6qJ-y3-lrC">
-                                <rect key="frame" x="16" y="80" width="343" height="158.5"/>
+                                <rect key="frame" x="16" y="80" width="343" height="204.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abP-rh-ztv">
                                         <rect key="frame" x="0.0" y="0.0" width="123" height="30"/>
@@ -159,8 +187,15 @@
                                             <segue destination="c2W-56-U4J" kind="show" id="Kuc-D8-OXf"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOi-Ah-0Cs">
+                                        <rect key="frame" x="0.0" y="138" width="181" height="30"/>
+                                        <state key="normal" title="Move ShareExtension Test"/>
+                                        <connections>
+                                            <segue destination="2Fz-gv-lA9" kind="show" id="riD-4Y-TK5"/>
+                                        </connections>
+                                    </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZV1-ZJ-YW3">
-                                        <rect key="frame" x="0.0" y="138" width="343" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="184" width="343" height="20.5"/>
                                         <color key="backgroundColor" red="0.92538958787918091" green="0.92554813623428345" blue="0.92537957429885864" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>

--- a/Project_SOS/Project_SOS/JS_Test/JS_TestShareViewController.swift
+++ b/Project_SOS/Project_SOS/JS_Test/JS_TestShareViewController.swift
@@ -1,0 +1,38 @@
+//
+//  JS_TestShareViewController.swift
+//  Project_SOS
+//
+//  Created by leejaesung on 2017. 9. 29..
+//  Copyright © 2017년 joe. All rights reserved.
+//
+
+import UIKit
+
+class JS_TestShareViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+    }
+    
+    // 테스트 공유 버튼 액션 정의
+    @IBAction func buttonShareAction(_ sender: UIButton) {
+        let text = "Hello Swift"
+        
+        shareTextOf(text: text)
+    }
+    
+    
+    // MARK: 텍스트 공유 기능 function 정의
+    func shareTextOf(text: String) {
+        let activityVC = UIActivityViewController(activityItems: [text], applicationActivities: nil) // 액티비티 뷰 컨트롤러 설정
+        activityVC.popoverPresentationController?.sourceView = self.view // 아이패드에서 작동하도록 pop over로 설정
+        activityVC.excludedActivityTypes = [ UIActivityType.airDrop, UIActivityType.addToReadingList, UIActivityType.saveToCameraRoll ] // 제외 타입 설정
+        
+        self.present(activityVC, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
공유 기능을 구현 완료하였습니다.
소스는 간단한데, 엉뚱한 걸 찾아보느라 시간이 걸렸네요. -_-b
그냥 가져가셔서 사용하시면 됩니다. 슝슝-

이전 PR과 마찬가지로 메인 스토리보드를 저의 스토리보드로 바꿔보시고 빌드하시면, 작동하는 것을 보실 수 있습니다.
현재 텍스트만 공유 가능한데, 현재 화면의 `질문 + 답`을 한개의 스트링으로 만드셔서 던지면 될 것 같아요.

출시 후, 다음 버전에서 이미지도 함께 공유되도록 해보겠숩니다. 🥇 