### PR TITLE
[추가] 좋아요(Favorite) 모아보기 기능구현

### DIFF
--- a/Project_SOS/Project_SOS/BY_DetailViewController.swift
+++ b/Project_SOS/Project_SOS/BY_DetailViewController.swift
@@ -273,7 +273,6 @@ class BY_DetailViewController: UIViewController {
             case 0:
                 self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
                 self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "Like_off"), for: .normal)
-                print("안찍히나오")
             case 1:
                 self.favoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)
                 self.navigationViewFavoriteButtonOutlet.setImage(#imageLiteral(resourceName: "likeCountIcon"), for: .normal)

--- a/Project_SOS/Project_SOS/BY_MainTableViewController.swift
+++ b/Project_SOS/Project_SOS/BY_MainTableViewController.swift
@@ -16,15 +16,15 @@ class BY_MainTableViewController: UITableViewController {
     
     var questionTitleData:[String] = []
     var questionTagData:[String] = []
-    var questionFavoriteCount:Int = 0
     var selectedQuestionID:Int?
+    
     
     //선택한 캐릭터가 있는지 확인
     var selectedCharater:String?
     
     //좋아요한 목록 표시 관련
     var isfavoriteTableView:Bool = false
-    var favoriteList:[Int] = []
+    var favoriteQuestionIDs:[Int] = []
     
     //검색 관련
     var isSearchBarClicked:Bool = false
@@ -48,7 +48,7 @@ class BY_MainTableViewController: UITableViewController {
             
         }
     }
-
+    
     //네비게이션 바
     @IBOutlet weak var navigationBarLogoButtonOutlet: UIButton!
     
@@ -59,6 +59,7 @@ class BY_MainTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        //ALL 데이터 가져오기
         Database.database().reference().child(Constants.question).observe(.value, with: { (snapshot) in
             guard let data = snapshot.value as? [[String:Any]] else { return }
             let tempArray = data.map({ (dic) -> String in
@@ -73,7 +74,7 @@ class BY_MainTableViewController: UITableViewController {
             
             self.questionTagData = tempTagArray
             self.questionTitleData = tempArray
-
+            
             self.tableView.reloadData()
             
         }) { (error) in
@@ -97,13 +98,28 @@ class BY_MainTableViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         
-        self.tableView.reloadData()
         tableView.register(UINib.init(nibName: "BY_MainTableViewCell", bundle: nil), forCellReuseIdentifier: "MainTableViewCell")
         awakeFromNib()
+        
         
         if UserDefaults.standard.object(forKey: "SelectedCharacter") != nil {
             self.selectedCharater = UserDefaults.standard.object(forKey: "SelectedCharacter") as! String
         }
+        
+        //FAVOTRITE 데이터 가져오기
+        if Auth.auth().currentUser?.uid != nil {
+            Database.database().reference().child(Constants.like).queryOrdered(byChild: Constants.like_User_Id).queryEqual(toValue: Auth.auth().currentUser?.uid).observeSingleEvent(of: .value, with: { (snapshot) in
+                guard let tempLikeData = snapshot.value as? [String:[String:Any]] else {return}
+                let tempUsersLikeData = tempLikeData.map({ (dic) -> Int in
+                    let likedQuestionID = dic.value[Constants.like_QuestionId] as! Int
+                    return likedQuestionID
+                })
+                self.favoriteQuestionIDs = tempUsersLikeData.sorted()
+            }, withCancel: { (error) in
+                print("즐겨찾기 데이터 에러", error.localizedDescription)
+            })
+        }
+        self.tableView.reloadData()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -119,6 +135,23 @@ class BY_MainTableViewController: UITableViewController {
     //MARK:-         Functions                 //
     /*******************************************/
     
+    //Firebase 데이터 가져오는 부분
+    func requestFavoriteQuestionDataFor(questionID:Int, completion:@escaping (_ info:[[String:String]]) -> Void) {
+        Database.database().reference().child(Constants.question).queryOrdered(byChild: Constants.question_QuestionId).observeSingleEvent(of: .value, with: { (snapshot) in
+            guard let tempQuestionData = snapshot.value as? [[String:Any]] else {return print("좋아요테스트: 여기서 안됨 \(snapshot.value)")}
+            let tempQuestionDic = tempQuestionData.map({ (dic) -> [String:String] in
+                var questionTitle:String = dic[Constants.question_QuestionTitle] as! String
+                var questionTag:String = dic[Constants.question_Tag] as! String
+                return ["QuestionTitle":questionTitle, "QuestionTag":questionTag]
+            })
+            completion(tempQuestionDic)
+            
+        }) { (error) in
+            print(error.localizedDescription)
+        }
+    }
+    
+    
     //테이블뷰 설정 부분
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
@@ -128,14 +161,11 @@ class BY_MainTableViewController: UITableViewController {
         
         if self.isSearchBarClicked == false {
             if self.isfavoriteTableView {
-//                print("좋아요 개수 \(DataCenter.standard.favoriteQuestions.count)")
-                return DataCenter.standard.favoriteQuestions.count
+                return self.favoriteQuestionIDs.count
             }else{
-//                print("전체 개수 \(self.questionTitleData.count)")
                 return self.questionTitleData.count
             }
         }else if self.isSearchBarClicked == true {
-//            print("검색 개수 \(self.visibleResults.count)")
             return self.visibleResults.count
         }else{
             print("셀개수에러")
@@ -145,13 +175,24 @@ class BY_MainTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell:BY_MainTableViewCell = tableView.dequeueReusableCell(withIdentifier: "MainTableViewCell", for: indexPath) as! BY_MainTableViewCell
-
-        cell.selectionStyle = .none
-
-        cell.titleQuestionLabel.text = self.questionTitleData[indexPath.row]
-        cell.tagLabel?.text = self.questionTagData[indexPath.row]
-        cell.loadLikeDatafor(questionID: indexPath.row)
         
+        cell.selectionStyle = .none
+        
+        //ALL 이냐 FAVORITE 냐
+        if isfavoriteTableView == false {
+            cell.titleQuestionLabel.text = self.questionTitleData[indexPath.row]
+            cell.tagLabel?.text = self.questionTagData[indexPath.row]
+            cell.loadLikeDatafor(questionID: indexPath.row)
+        }else{
+            var index:Int = self.favoriteQuestionIDs[indexPath.row]
+            self.requestFavoriteQuestionDataFor(questionID: index, completion: { (dic) in
+                cell.titleQuestionLabel.text = dic[index]["QuestionTitle"]
+                cell.tagLabel?.text = dic[index]["QuestionTag"]
+                cell.loadLikeDatafor(questionID: index)
+            })
+        }
+        
+        //SearchView냐 아니냐
         if self.isSearchBarClicked == false {
             if self.isfavoriteTableView {
                 cell.titleQuestionLabel.text = ""
@@ -162,18 +203,25 @@ class BY_MainTableViewController: UITableViewController {
         }else if self.isSearchBarClicked == true {
             cell.titleQuestionLabel.text = self.visibleResults[indexPath.row]
         }
+        
         return cell
     }
-
+    
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 97
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let currentCell = tableView.cellForRow(at: indexPath) as! BY_MainTableViewCell
-        self.selectedQuestionID = currentCell.questionID
-        
         let nextViewController:BY_DetailViewController = storyboard?.instantiateViewController(withIdentifier: "DetailViewController") as! BY_DetailViewController
+        
+        if isfavoriteTableView == false {
+            self.selectedQuestionID = currentCell.questionID
+        }else{
+            var index:Int = self.favoriteQuestionIDs[indexPath.row]
+            self.selectedQuestionID = index
+        }
+        
         nextViewController.questionID = self.selectedQuestionID
         self.navigationController?.pushViewController(nextViewController, animated: true)
     }

--- a/Project_SOS/Project_SOS/BY_MainTableViewController.swift
+++ b/Project_SOS/Project_SOS/BY_MainTableViewController.swift
@@ -106,7 +106,7 @@ class BY_MainTableViewController: UITableViewController {
             self.selectedCharater = UserDefaults.standard.object(forKey: "SelectedCharacter") as! String
         }
         
-        //FAVOTRITE 데이터 가져오기
+        //FAVORITE 데이터 가져오기
         if Auth.auth().currentUser?.uid != nil {
             Database.database().reference().child(Constants.like).queryOrdered(byChild: Constants.like_User_Id).queryEqual(toValue: Auth.auth().currentUser?.uid).observeSingleEvent(of: .value, with: { (snapshot) in
                 guard let tempLikeData = snapshot.value as? [String:[String:Any]] else {return}

--- a/Project_SOS/Project_SOS/BY_SearchPresentOverNavigationBarViewController.swift
+++ b/Project_SOS/Project_SOS/BY_SearchPresentOverNavigationBarViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Firebase
 
 class BY_SearchPresentOverNavigationBarViewController: BY_MainTableViewController {
     
@@ -14,18 +15,29 @@ class BY_SearchPresentOverNavigationBarViewController: BY_MainTableViewControlle
     //MARK:-        Properties                 //
     /*******************************************/
     var searchController: UISearchController!
+    @IBOutlet weak var sortTableContentsSegmentedControlOutlet: UISegmentedControl!
     
     
     /*******************************************/
     //MARK:-        LifeCycle                  //
     /*******************************************/
     
-    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        
+        self.sortTableContentsSegmentedControlOutlet.titleForSegment(at: 0) == "All"
+        self.sortTableContentsSegmentedControlOutlet.selectedSegmentIndex = 0
+        self.isfavoriteTableView = false
+        
+        self.tableView.reloadData()
+    }
     
     /*******************************************/
     //MARK:-         Functions                 //
     /*******************************************/
     @IBAction func searchButtonClicked(_ button: UIBarButtonItem) {
+        
+        self.isfavoriteTableView = false
         
         UIBarButtonItem.appearance(whenContainedInInstancesOf:[UISearchBar.self]).tintColor = UIColor(red: 255, green: 0, blue: 0, alpha: 1)
 
@@ -59,6 +71,25 @@ class BY_SearchPresentOverNavigationBarViewController: BY_MainTableViewControlle
             let characterIntroduceViewController:BY_CharacterIntroduceViewController = self.storyboard?.instantiateViewController(withIdentifier: "CharacterIntroduceViewController") as! BY_CharacterIntroduceViewController
             self.present(characterIntroduceViewController, animated: true, completion: nil)
         }
+        
+        let resetFavoriteSettingAction:UIAlertAction = UIAlertAction.init(title: "즐겨찾기 초기화", style: .default) { (alert) in
+            Database.database().reference().child(Constants.like).queryOrdered(byChild: Constants.like_User_Id).queryEqual(toValue: Auth.auth().currentUser?.uid).observeSingleEvent(of: .value, with: { (snapshot) in
+                guard let tempLikeData = snapshot.value as? [String:[String:Any]] else {return}
+                let tempLikeKeyString = tempLikeData.map({ (dic) -> String in
+                    return dic.key
+                })
+                
+                for index in 0..<tempLikeKeyString.count {
+                Database.database().reference().child(Constants.like).child(tempLikeKeyString[index]).setValue(nil)
+                }
+                
+                self.favoriteQuestionIDs = []
+                self.tableView.reloadData()
+            }, withCancel: { (error) in
+                print(error.localizedDescription)
+            })
+        }
+        
         let resetCharacterSettingAction:UIAlertAction = UIAlertAction.init(title: "캐릭터 설정 초기화", style: .default) { (alert) in
             UserDefaults.standard.removeObject(forKey: "SelectedCharacter")
             print("선택했던 캐릭터 값이 초기화 되었습니다. 현재 캐릭터 상태값:\(UserDefaults.standard.object(forKey: "SelectedCharacter") ?? "선택된 캐릭터가 없습니다.")")
@@ -68,6 +99,7 @@ class BY_SearchPresentOverNavigationBarViewController: BY_MainTableViewControlle
         
         alert.addAction(rateAppAction)
         alert.addAction(indroduceDevelopersAction)
+        alert.addAction(resetFavoriteSettingAction)
         alert.addAction(resetCharacterSettingAction)
         alert.addAction(cancelAction)
         

--- a/Project_SOS/Project_SOS/Base.lproj/Main.storyboard
+++ b/Project_SOS/Project_SOS/Base.lproj/Main.storyboard
@@ -871,6 +871,7 @@ IT 서비스 기획자를 전전하다가  늦깎이 iOS 개발자가 되었�
                     </navigationItem>
                     <connections>
                         <outlet property="navigationBarLogoButtonOutlet" destination="sPp-1z-Y9W" id="76d-po-jU2"/>
+                        <outlet property="sortTableContentsSegmentedControlOutlet" destination="AfK-NQ-63X" id="iHb-E2-ZUb"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4Uj-gb-JfZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -917,7 +918,7 @@ IT 서비스 기획자를 전전하다가  늦깎이 iOS 개발자가 되었�
         <image name="TitleCellBackground" width="375" height="125"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="Bl2-S5-sXv"/>
+        <segue reference="XmX-ca-eJd"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
 </document>


### PR DESCRIPTION
1. 유저별, 좋아요 누른 질문만 Main의 Favorite 통해 모아보기

2. Main의 햄버거 메뉴에 즐겨찾기 초기화 기능 추가 (Firebase 연동 및 UI)

> * 뷰, 뷰컨간 이동에 따라서 좋아요카운트라벨이 뒤늦게 업데이트 되는게 눈으로 좀 보여요. 좋아요 별표도 마찬가지구요. 해당부분 쓰레드로 어떻게 해결하고 싶은데.. 익숙하지도 않고 당장은 모르겠습니다. 
> * 최소한 모든 정보가 뜨기 전까진 셀 상에 아무런 정보가 뜨지 않고 인디케이터가 돌아간다던가.. 그렇게요.