### PR TITLE
[수정] 이미지 오픈소스 교체

### DIFF
--- a/Project_SOS/Podfile
+++ b/Project_SOS/Podfile
@@ -16,6 +16,6 @@ pod 'Google-Mobile-Ads-SDK'
 
 pod "SimpleMarkdownParser", '~> 0.5.3'
 
-pod 'SDWebImage'
+pod 'Kingfisher', '~> 4.1'
 
 end

--- a/Project_SOS/Podfile.lock
+++ b/Project_SOS/Podfile.lock
@@ -44,15 +44,13 @@ PODS:
     - GoogleToolboxForMac/NSString+URLArguments (= 2.1.1)
   - GoogleToolboxForMac/NSString+URLArguments (2.1.1)
   - GTMSessionFetcher/Core (1.1.12)
+  - Kingfisher (4.1.0)
   - leveldb-library (1.18.3)
   - nanopb (0.3.8):
     - nanopb/decode (= 0.3.8)
     - nanopb/encode (= 0.3.8)
   - nanopb/decode (0.3.8)
   - nanopb/encode (0.3.8)
-  - SDWebImage (4.1.0):
-    - SDWebImage/Core (= 4.1.0)
-  - SDWebImage/Core (4.1.0)
   - SimpleMarkdownParser (0.5.4)
 
 DEPENDENCIES:
@@ -61,7 +59,7 @@ DEPENDENCIES:
   - Firebase/Database
   - Firebase/Storage
   - Google-Mobile-Ads-SDK
-  - SDWebImage
+  - Kingfisher (~> 4.1)
   - SimpleMarkdownParser (~> 0.5.3)
 
 SPEC CHECKSUMS:
@@ -75,11 +73,11 @@ SPEC CHECKSUMS:
   Google-Mobile-Ads-SDK: ed8004a7265b424568dc84f3d2bbe3ea3fff958f
   GoogleToolboxForMac: 8e329f1b599f2512c6b10676d45736bcc2cbbeb0
   GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
+  Kingfisher: f14df8cbe576bf55f211fa589e9869bceb4ea87d
   leveldb-library: 10fb39c39e243db4af1828441162405bbcec1404
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
-  SDWebImage: 0e435c14e402a6730315a0fb79f95e68654d55a4
   SimpleMarkdownParser: ffe7fc0106c15662f752f9e9e3d33d011d4aff92
 
-PODFILE CHECKSUM: 77faff530e037dbafda172cea8f176c6e020a2df
+PODFILE CHECKSUM: d13b7b78446603e098a3455d01cddad618b96c8a
 
 COCOAPODS: 1.3.1

--- a/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
+++ b/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
@@ -110,15 +110,6 @@
 			name = "BY_Search Controllers";
 			sourceTree = "<group>";
 		};
-		6AD85B371F78ACBC008DB11B /* BY_ViewPager */ = {
-			isa = PBXGroup;
-			children = (
-				6AFBF11D1F74E3D600C0F2D1 /* BY_DetailTableViewCell.swift */,
-				6AFBF11E1F74E3D600C0F2D1 /* BY_DetailTableViewCell.xib */,
-			);
-			name = BY_ViewPager;
-			sourceTree = "<group>";
-		};
 		886DD1A360487A28B9FE895F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -175,11 +166,12 @@
 				6A33C8621F614D19005FC0A8 /* BY_MainTableViewCell.swift */,
 				6A33C8631F614D19005FC0A8 /* BY_MainTableViewCell.xib */,
 				6AFBF1231F74F97A00C0F2D1 /* BY_DetailViewController.swift */,
+				6AFBF11D1F74E3D600C0F2D1 /* BY_DetailTableViewCell.swift */,
+				6AFBF11E1F74E3D600C0F2D1 /* BY_DetailTableViewCell.xib */,
 				6A33C85B1F6149C1005FC0A8 /* BY_CharacterChoiceViewController.swift */,
 				6A15CBC31F72806800F74B1A /* BY_CharacterIntroduceViewController.swift */,
 				6AC2A4281F81097A00138FCA /* Assets.xcassets */,
 				FE4FE6E71F6C24B00052AFB0 /* JS_Test */,
-				6AD85B371F78ACBC008DB11B /* BY_ViewPager */,
 				6A33C8661F617226005FC0A8 /* BY_Search Controllers */,
 				D8321BEB1F6AB85F006D7506 /* SM_DataTest */,
 				D86539581F5E8C2B00D34790 /* Info.plist */,
@@ -295,7 +287,7 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-Project_SOS/Pods-Project_SOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
-				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
+				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
 				"${BUILT_PRODUCTS_DIR}/SimpleMarkdownParser/SimpleMarkdownParser.framework",
 				"${BUILT_PRODUCTS_DIR}/leveldb-library/leveldb.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
@@ -304,7 +296,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SimpleMarkdownParser.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/leveldb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",

--- a/Project_SOS/Project_SOS/BY_MainTableViewCell.swift
+++ b/Project_SOS/Project_SOS/BY_MainTableViewCell.swift
@@ -59,7 +59,7 @@ class BY_MainTableViewCell: UITableViewCell {
                     guard let tempLikeDatas = snapshot.value as? [String:[String:Any]] else {return}
                     
                     let filteredLikeData = tempLikeDatas.filter({ (dic:(key: String, value: [String : Any])) -> Bool in
-                        var exhibitionID:Int = dic.value[Constants.like_QuestionId] as! Int
+                        let exhibitionID:Int = dic.value[Constants.like_QuestionId] as! Int
                         return exhibitionID == questionID
                     })
                     


### PR DESCRIPTION
1. `BY_DetailViewController` 에 import 되었던 이미지 관련 오픈소스를 `SDWebImage`에서 `Kingfinsher`로 변경하였습니다.

2. 캐릭터가 선택되지 않은 상태에서, 캐릭터를 선택한 후 `DetailTableView`의 `numberOfRowInSection` 이 `0`으로 나오는 문제 수정하였습니다. 지금은 캐릭터를 선택한 즉시 해당 캐릭터의 답변이 보이게 됩니다.

> ISSUE #61
>* Slack에 나온바와 같이 이미지 로딩 문제가 있습니다. (URL로 가져온 이미지가 말풍선을 넘어서는 문제)
>
> * **사례1: 선택한 캐릭터의 답변 상단에 이미지가 있을 때.** 
> * ![img_7692](https://user-images.githubusercontent.com/27915244/31076519-77ff6de8-a7b5-11e7-9808-52b433fcd2a6.PNG)
>
> * **사례2: 답변 하단에 있더라도 종종 이미지가 제대로 된 크기로 나타나지 않습니다.**
> * ![img_7694](https://user-images.githubusercontent.com/27915244/31076547-aed25664-a7b5-11e7-8e9d-f93853ca4313.PNG)
>
> * **사례3: 메인뷰로 나갔다 들어왔을 때 역시 난리남**
> * ![img_7693](https://user-images.githubusercontent.com/27915244/31076552-c16eee04-a7b5-11e7-9b2d-c54113f9413d.PNG)
> 
> * **정상적인 모습들: 상기 사례의 문제들은, 다른 세그(캐릭터)로 넘나들고 돌아오면 정상적으로 표시됩니다.**
> * ![img_7696](https://user-images.githubusercontent.com/27915244/31076570-d65eaf2a-a7b5-11e7-8bf8-830fdf69b6c5.PNG)
> * ![img_7695](https://user-images.githubusercontent.com/27915244/31076572-d78b298c-a7b5-11e7-8821-2f2976898806.PNG)
> 
> 어떻게 고칠 수 있을까요...ㅠ