### PR TITLE
[주의!][Update] 앱 번들 아이디 및 파이어베이스 plist 교체

### DIFF
--- a/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
+++ b/Project_SOS/Project_SOS.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 				INFOPLIST_FILE = Project_SOS/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sos.project-sos";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sos.projectsos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};
@@ -510,7 +510,7 @@
 				INFOPLIST_FILE = Project_SOS/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sos.project-sos";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sos.projectsos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};

--- a/Project_SOS/Project_SOS/BY_DetailViewController.swift
+++ b/Project_SOS/Project_SOS/BY_DetailViewController.swift
@@ -255,6 +255,7 @@ class BY_DetailViewController: UIViewController {
     
     
     //MARK: 공유하기 버튼 액션 정의 - by 재성
+    // 검색 > 디테일 화면으로 들어왔을 때, 표시되는 커스텀 내비게이션 바에도 같은 내용 구현하기 ( '공유하기 버튼(커스텀 내비게이션 바) 액션 정의'로 주석 처리 )
     @IBAction func shareButtonAction(_ sender: UIButton) {
         var sharingText = ""
         
@@ -315,8 +316,28 @@ class BY_DetailViewController: UIViewController {
     }
     
     //--Share Button
-    //TODO: (재성님!)여기에 공유에 대한 기능을 구현해주세요 / 기존 NavigationBar 상의 버튼에 구현했던 것과 동일
+    //MARK: 공유하기 버튼(커스텀 내비게이션 바) 액션 정의
     @IBAction func navigationViewShareButtonAction(_ sender: UIButton) {
+        var sharingText = ""
+        
+        switch self.characterSelectSegmentedControl.selectedSegmentIndex {
+        case 0: //"보영 선택시"
+            print("///// shareButtonAction: 보영 \(self.byAnswer.count)")
+            sharingText = ( (self.contentSharingTitle!) + "\n\n" + self.findSharingAnswerTextsOnlyOf(answer: self.byAnswer) )
+            
+        case 1: //"선미 선택시"
+            print("///// shareButtonAction: 선미 \(self.smAnswer.count)")
+            sharingText = ( (self.contentSharingTitle!) + "\n\n" + self.findSharingAnswerTextsOnlyOf(answer: self.smAnswer) )
+            
+        case 2: //"재성 선택시"
+            print("///// shareButtonAction: 재성 \(self.jsAnswer.count)")
+            sharingText = ( (self.contentSharingTitle!) + "\n\n" + self.findSharingAnswerTextsOnlyOf(answer: self.jsAnswer) )
+            
+        default:
+            print("///// shareButtonAction: no data")
+        }
+        
+        shareTextOf(text: sharingText)
     }
     
     //--Like Button


### PR DESCRIPTION
#74 #75 2개 이슈를 해결한 PR입니다.

**1.** 어제 오프라인 미팅에서 이야기했던, 검색으로 들어간 디테일 뷰의 공유하기 버튼 funtion을 구현하였습니다. ~코드 복붙..~

# 2. 주의 사항!!!
지금 사용하던 `plist`가 ~공공재처럼~ 깃헙에 올라와 있으므로, 출시 직전에 파이어베이스 `plist`를 교체하고자 합니다.
파이어베이스에 iOS 앱을 새로 등록해서 `plist`를 새로 받으려고 했더니, ~당연하게도..~ 번들 ID가 겹치면 안되더라구요.
그래서 새로 앱을 만들고, 번들 아이디를 ~제멋대로~ 수정했습니다.

따라서 이 PR을 Pull 땡기신 후에 파이어베이스에 가셔서 새로 만들어둔 `plist`를 받으시길 바래요.
그리고 두 분 확인이 되면, 이전 iOS 앱은 제거해주시길 바랍니다. 🗑  ~저는 새 plist를 적용시켰으니까, 조용히 지우시면 됩니다.~

파이어베이스 홈에서 아래와 같이 설정에 들어가시면 됩니다.
<img width="478" alt="2017-10-11 5 09 29" src="https://user-images.githubusercontent.com/28520038/31432156-cba83540-aeb0-11e7-979e-5ed2dc07a6fd.png">

파이어베이스 상에서 `SOS iOS`가 새로 만든 iOS 앱입니다.